### PR TITLE
Attachment Validation

### DIFF
--- a/TabulateSmarterTestContentPackage/Models/CssElement.cs
+++ b/TabulateSmarterTestContentPackage/Models/CssElement.cs
@@ -1,0 +1,10 @@
+﻿using System.Xml.Linq;
+
+namespace TabulateSmarterTestContentPackage.Models
+{
+    public class CssElement
+    {
+        public XElement Element { get; set; }
+        public string Style { get; set; }
+    }
+}

--- a/TabulateSmarterTestContentPackage/Program.cs
+++ b/TabulateSmarterTestContentPackage/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using NLog;
 using TabulateSmarterTestContentPackage.Utilities;
 using Win32Interop;
@@ -170,6 +171,17 @@ Error severity definitions:
                 {
                     SettingsUtility.RetrieveAslValues();
                 }
+
+                Console.WriteLine("Tabulator Flags");
+                Console.WriteLine(Enumerable.Repeat("-",20).Aggregate((x,y) => $"{x}{y}"));
+
+                gValidationOptions.Keys.ToList().ForEach(x =>
+                {
+                    Console.WriteLine($"[{x}: {gValidationOptions[x].ToString()}]");
+                });
+
+                Console.WriteLine(Enumerable.Repeat("-", 20).Aggregate((x, y) => $"{x}{y}"));
+                Console.WriteLine();
 
                 var tab = new Tabulator();
                 switch (operation)

--- a/TabulateSmarterTestContentPackage/TabulateSmarterTestContentPackage.csproj
+++ b/TabulateSmarterTestContentPackage/TabulateSmarterTestContentPackage.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Models\BrailleFile.cs" />
     <Compile Include="Models\BrailleFileType.cs" />
     <Compile Include="Models\BrailleSupport.cs" />
+    <Compile Include="Models\CssElement.cs" />
     <Compile Include="Models\ErrorCategory.cs" />
     <Compile Include="Models\ErrorSeverity.cs" />
     <Compile Include="Models\HtmlImageTag.cs" />

--- a/TabulateSmarterTestContentPackage/Validators/AslVideoValidator.cs
+++ b/TabulateSmarterTestContentPackage/Validators/AslVideoValidator.cs
@@ -23,9 +23,10 @@ namespace TabulateSmarterTestContentPackage.Validators
                 {
                     try
                     {
-                        double videoSeconds = Mp4VideoUtility.GetDuration(Path.Combine(((FsFolder)ffItems).mPhysicalPath,
-                                                  itemContext.FfItem.Name,
-                                                  attachmentFile)) / 1000;
+                        double videoSeconds = Mp4VideoUtility.GetDuration(
+                                                  Path.Combine(((FsFolder) ffItems).mPhysicalPath,
+                                                      itemContext.FfItem.Name,
+                                                      attachmentFile)) / 1000;
                         var cData = CDataExtractor.ExtractCData(xmlDocument.MapToXDocument()
                             .XPathSelectElement("itemrelease/item/content[@language='ENU']/stem"))?.FirstOrDefault();
                         int? characterCount = 0;
@@ -43,10 +44,12 @@ namespace TabulateSmarterTestContentPackage.Validators
                             return;
                         }
                         var secondToCountRatio = videoSeconds / characterCount;
-                        var highStandard = TabulatorSettings.AslMean + (TabulatorSettings.AslStandardDeviation * TabulatorSettings.AslTolerance);
-                        var lowStandard = TabulatorSettings.AslMean - (TabulatorSettings.AslStandardDeviation * TabulatorSettings.AslTolerance);
+                        var highStandard = TabulatorSettings.AslMean +
+                                           (TabulatorSettings.AslStandardDeviation * TabulatorSettings.AslTolerance);
+                        var lowStandard = TabulatorSettings.AslMean -
+                                          (TabulatorSettings.AslStandardDeviation * TabulatorSettings.AslTolerance);
                         if (secondToCountRatio > highStandard
-                                || secondToCountRatio < lowStandard)
+                            || secondToCountRatio < lowStandard)
                         {
                             ReportingUtility.ReportError(itemContext, ErrorCategory.Item, ErrorSeverity.Degraded,
                                 $"ASL enabled element's video length ({videoSeconds}) to character count ({characterCount}) ratio ({secondToCountRatio}) falls more than " +
@@ -58,6 +61,10 @@ namespace TabulateSmarterTestContentPackage.Validators
                     {
                         Console.WriteLine(ex);
                     }
+                }
+                else
+                {
+                    // throw errors
                 }
         }
     }


### PR DESCRIPTION
- Added active flags to console output
- Added attachment ID uniqueness validation
- Added benign error for stimuli who name their braille resources with "passage" instead of the documented "stim"
- Isolated css extraction code in the CDataValidator