### PR TITLE
Clarify error messages, reduce noise in error reports, clean up conso…

### DIFF
--- a/TabulateSmarterTestContentPackage/Program.cs
+++ b/TabulateSmarterTestContentPackage/Program.cs
@@ -106,6 +106,9 @@ Error severity definitions:
             gValidationOptions.Disable("uwt"); // Disable Unreferenced Wordlist Terms
             gValidationOptions.Disable("mwa"); // Disable checking for attachments on unreferenced wordlist terms
             gValidationOptions.Disable("iat"); // Disable checking for images without alternate text
+            gValidationOptions.Disable("css"); // Disable reporting css color-contrast interference (temporary fix)
+
+            LogManager.DisableLogging();
 
             try
             {
@@ -206,10 +209,12 @@ Error severity definitions:
             }
             catch (Exception ex)
             {
+                Console.WriteLine(ex.Message);
                 Logger.Error(ex.Message);
             }
 
             var elapsedTicks = Environment.TickCount - startTicks;
+            Console.WriteLine("Elapsed time: {0}.{1:d3} seconds", elapsedTicks / 1000, elapsedTicks % 1000);
             Logger.Info("Elapsed time: {0}.{1:d3} seconds", elapsedTicks / 1000, elapsedTicks % 1000);
 
             if (ConsoleHelper.IsSoleConsoleOwner)

--- a/TabulateSmarterTestContentPackage/Tabulator.cs
+++ b/TabulateSmarterTestContentPackage/Tabulator.cs
@@ -865,7 +865,7 @@ namespace TabulateSmarterTestContentPackage
             // Validate claim
             if (primaryStandards.Any(x => !sValidClaims.Contains(x.Claim)))
             {
-                ReportingUtility.ReportError(it, ErrorCategory.Metadata, ErrorSeverity.Degraded, "Unexpected claim value.", "Claim='{0}'", primaryStandards.First(x => !sValidClaims.Contains(x.Claim)).Claim);
+                ReportingUtility.ReportError(it, ErrorCategory.Metadata, ErrorSeverity.Degraded, "Unexpected claim value (Should be 1, 2, 3, or 4 with possible suffix).", "Claim='{0}'", primaryStandards.First(x => !sValidClaims.Contains(x.Claim)).Claim);
             }
 
             // Validate target grade suffix (Generating lots of errors. Need to follow up.)
@@ -2341,7 +2341,7 @@ namespace TabulateSmarterTestContentPackage
                             }
                             if (!filenameListType.Equals(listType))
                             {
-                                ReportingUtility.ReportWitError(itemIt, it, ErrorSeverity.Degraded, "Wordlist attachment filename indicates attachment type mismatch.", "filename='{0}' filenameListType='{1}' expectedListType='{2}'", filename, filenameListType, listType);
+                                ReportingUtility.ReportWitError(itemIt, it, ErrorSeverity.Degraded, "Wordlist audio filename indicates attachment language mismatch.", "filename='{0}' filenameListType='{1}' expectedListType='{2}'", filename, filenameListType, listType);
                             }
                         }
 
@@ -2384,7 +2384,7 @@ namespace TabulateSmarterTestContentPackage
                 int index = termIndices[i];
                 if (index >= wordlistTerms.Count || string.IsNullOrEmpty(wordlistTerms[index]))
                 {
-                    ReportingUtility.ReportWitError(itemIt, it, ErrorSeverity.Tolerable, "Item references non-existent wordlist term.", "text='{0}' termIndex='{1}'", terms[i], index);
+                    ReportingUtility.ReportWitError(itemIt, it, ErrorSeverity.Benign, "Item references non-existent wordlist term.", "text='{0}' termIndex='{1}'", terms[i], index);
                 }
                 else
                 {
@@ -2438,7 +2438,7 @@ namespace TabulateSmarterTestContentPackage
                     }
                     else
                     {
-                        ReportingUtility.ReportWitError(itemIt, it, ErrorSeverity.Severe, "Wordlist attachment filename differs in capitalization (will fail on certain platforms).",
+                        ReportingUtility.ReportWitError(itemIt, it, ErrorSeverity.Degraded, "Wordlist audio filename differs in capitalization (will fail on certain platforms).",
                             "referenceFilename='{0}' actualFilename='{1}' termIndex='{2}'", filename, caseMismatchFilename, termIndex);
                     }
                 }

--- a/TabulateSmarterTestContentPackage/Tabulator.cs
+++ b/TabulateSmarterTestContentPackage/Tabulator.cs
@@ -824,18 +824,15 @@ namespace TabulateSmarterTestContentPackage
                 }
 
                 // If non-embedded answer key (either hand-scored or QRX scoring but not EBSR type check for a rubric (human scoring guidance)
+                // We only care about english rubrics (at least for the present)
                 if (scoringType != ScoringType.Basic && !it.ItemType.Equals("EBSR", StringComparison.OrdinalIgnoreCase))
                 {
-                    xml.SelectNodes("itemrelease/item/content")?.Cast<XmlElement>().ToList().ForEach(
-                        x =>
-                        {
-                            if (!(x.SelectSingleNode("./rubriclist/rubric/val") is XmlElement))
-                            {
-                                ReportingUtility.ReportError(it, ErrorCategory.AnswerKey, ErrorSeverity.Tolerable, 
-                                    "Hand-scored or QRX-scored item lacks a human-readable rubric", 
-                                    $"Language: {x.SelectSingleNode("./@language")?.Value ?? string.Empty} AnswerKey: '{answerKey}'");
-                            }
-                        });
+                    if (!(xml.SelectSingleNode("itemrelease/item/content[@language='ENU']/rubriclist/rubric/val") is XmlElement))
+                    {
+                        ReportingUtility.ReportError(it, ErrorCategory.AnswerKey, ErrorSeverity.Tolerable,
+                            "Hand-scored or QRX-scored item lacks a human-readable rubric",
+                            $"AnswerKey: '{answerKey}'");
+                    }
                 }
             }
 
@@ -862,7 +859,7 @@ namespace TabulateSmarterTestContentPackage
             }
             if (primaryStandards.Any(x => string.IsNullOrEmpty(x.Standard)))
             {
-                ReportingUtility.ReportError(it, ErrorCategory.Metadata, ErrorSeverity.Degraded, "No PrimaryStandard specified in metadata.");
+                ReportingUtility.ReportError(it, ErrorCategory.Metadata, ErrorSeverity.Degraded, "Common Core Standard not included in PrimaryStandard metadata.");
             }
 
             // Validate claim
@@ -922,10 +919,10 @@ namespace TabulateSmarterTestContentPackage
 
             if (!it.IsPassage && Program.gValidationOptions.IsEnabled("asl") && CheckForAttachment(it, xml, "ASL", "MP4"))
             {
-                AslVideoValidator.Validate(mPackageFolder, it, xml);
+                AslVideoValidator.Validate(it, xml);
             }
 
-            Console.WriteLine($"Tabulating {it.ItemId}");
+            Logger.Info($"Tabulating {it.ItemId}");
 
             var scoringSeparation = scoringInformation.GroupBy(
                 x => !string.IsNullOrEmpty(x.Domain) && x.Domain.Equals("paper", StringComparison.OrdinalIgnoreCase)).ToList();
@@ -1422,7 +1419,7 @@ namespace TabulateSmarterTestContentPackage
                 if (fileTypes.Contains("brf") && fileTypes.Contains("prn")) // We have more than one Braille file extension present
                 {
                     ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Degraded, 
-                        "More than one Braille file type extension present in attachment list", $"File Types: [{fileTypes.Aggregate((x,y) => $"{x}|{y}")}]");
+                        "More than one braille embossing file type extension present in attachment list", $"File Types: [{fileTypes.Aggregate((x,y) => $"{x}|{y}")}]");
                 }
 
                 var processedIds = new List<string>();
@@ -1458,6 +1455,8 @@ namespace TabulateSmarterTestContentPackage
                         continue; // Not braille attachment
                     }
 
+                    // === From here forward we are only dealing with Braille attachments and the error messages reflect that ===
+
                     if (!attachType.Equals(brailleTypeMeta))
                     {
                         ReportingUtility.ReportError(it, ErrorCategory.Metadata, ErrorSeverity.Severe, "Braille metadata does not match attachment type.", "metadata='{0}', fileType='{1}'", brailleTypeMeta, attachType);
@@ -1473,7 +1472,7 @@ namespace TabulateSmarterTestContentPackage
                     }
                     if (!it.FfItem.FileExists(filename))
                     {
-                        ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Tolerable, "Dangling reference to attached file that does not exist.", "attachType='{0}' Filename='{1}'", attachType, filename);
+                        ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Tolerable, "Braille embossing file is missing.", "attachType='{0}' Filename='{1}'", attachType, filename);
                     }
 
                     // Check the extension
@@ -1481,7 +1480,7 @@ namespace TabulateSmarterTestContentPackage
                     if (extension.Length > 0) extension = extension.Substring(1); // Strip leading "."
                     if (!string.Equals(extension, attachType, StringComparison.OrdinalIgnoreCase))
                     {
-                        ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Degraded, "Unexpected extension for attached file.", "extension='{0}' expected='{1}' filename='{2}'", extension, attachType, filename);
+                        ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Degraded, "Braille ebossing filename has unexpected extension.", "extension='{0}' expected='{1}' filename='{2}'", extension, attachType, filename);
                     }
 
                     // Get the subtype (if any)
@@ -1499,78 +1498,76 @@ namespace TabulateSmarterTestContentPackage
                     else
                     {
                         ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Degraded, 
-                            "Unknown subtype designation for attachment.", subtype ?? "Subtype not present");
+                            "Braille embossing attachment has unknown subtype.", subtype ?? "Subtype not present");
                     }
 
-                    var matches = Regex.Matches(filename, validFilePattern);
-                    if (Regex.IsMatch(filename, validFilePattern))
+                    var match = Regex.Match(filename, validFilePattern);
+                    if (match.Success)
                     // We are not checking for these values if it's not a match.
                     {
                         var itemOrStimText = it.IsPassage ? "stim" : "item";
-                        if (!matches[0].Groups[1].Value.Equals(itemOrStimText, StringComparison.OrdinalIgnoreCase))
+                        if (!match.Groups[1].Value.Equals(itemOrStimText, StringComparison.OrdinalIgnoreCase))
                         // item or stim
                         {
                             if (it.IsPassage &&
-                                !matches[0].Groups[1].Value.Equals("passage", StringComparison.OrdinalIgnoreCase))
+                                !match.Groups[1].Value.Equals("passage", StringComparison.OrdinalIgnoreCase))
                             {
                                 ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Severe,
-                                    "Attachment target does not match item target (stim vs item)",
-                                    $"Target: {itemOrStimText} Filename: {filename} Actual Target: {matches[0].Groups[1].Value}");
+                                    "Braille embossing filename indicates item/stim mismatch.",
+                                    $"Target: {itemOrStimText} Filename: {filename} Actual Target: {match.Groups[1].Value}");
                             }
                             // According to the documentation, all stimuli braille attachments must be prefixed with "stim", 
                             // but functionally, they may be "passage". Indicate a benign error.
                             else
                             {
                                 ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Benign,
-                                    "Stimuli attachment designated as a \"passage\". Official documentation " +
-                                    "indicates all stimuli must be prefixed as \"stim\".",
+                                    "Braille embossing filename designated as a \"passage\", should be \"stim\".",
                                     filename);
                             }
                         }
-                        if (!matches[0].Groups[2].Value.Equals(it.ItemId, StringComparison.OrdinalIgnoreCase))
+                        if (!match.Groups[2].Value.Equals(it.ItemId, StringComparison.OrdinalIgnoreCase))
                         // item id
                         {
                             ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Severe,
-                                $"Attachment ID does not match item ID",
-                                $"Identifier: {it.ItemId} Filename: {filename} Target: {matches[0].Groups[2].Value}");
+                                "Braille embossing filename indicates item ID mismatch.",
+                                $"ItemId: {it.ItemId} FilenameId: {match.Groups[2].Value} Filename: {filename}");
                         }
-                        if (!matches[0].Groups[3].Value.Equals("enu", StringComparison.OrdinalIgnoreCase))
+                        if (!match.Groups[3].Value.Equals("enu", StringComparison.OrdinalIgnoreCase))
                         // this is hard-coded 'enu' English for now. No other values are valid
                         {
                             ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Severe,
-                                "Attachment language is non-ENU",
-                                $"Attachment Language: {matches[0].Groups[3].Value} Filename: {filename}");
+                                "Braille embossing filename indicates language other than \"ENU\".",
+                                $"Attachment Language: {match.Groups[3].Value} Filename: {filename}");
                         }
 
-                        if (!validTypes.Select(x => x.ToLower()).Contains(matches[0].Groups[4].Value.ToLower()))
+                        if (!validTypes.Select(x => x.ToLower()).Contains(match.Groups[4].Value.ToLower()))
                         // code, uncontracted, contracted, nemeth
                         {
                             ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Severe,
-                                "Braille attachment is of unknown type",
-                                $"Braille Type: {matches[0].Groups[4].Value} Filename: {filename} " +
-                                $"Valid Types: [{validTypes.Aggregate((x, y) => $"{x}|{y}")}]");
-                        } else if (!string.IsNullOrEmpty(subtype) && !matches[0].Groups[4].Value.Equals(subtype.Split('_').First(),
-                            StringComparison.OrdinalIgnoreCase))
-                        {
-                            ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Benign,
-                                "Attachment braille type does not match parent element's subtype",
-                                $"Attachment Braille Type: {matches[0].Groups[4].Value} " +
-                                $"Filename {filename} Element Braille Type: {subtype.Split('_').First()}");
+                                "Braille embossing filename indicates unknown braille type.",
+                                $"Braille Code: {match.Groups[4].Value} Filename: {filename}");
                         }
-                        if (!string.IsNullOrEmpty(matches[0].Groups[5].Value) &&
-                            !matches[0].Groups[5].Value.Equals("_transcript", StringComparison.OrdinalIgnoreCase))
+                        else if (!string.IsNullOrEmpty(subtype) && !match.Groups[4].Value.Equals(subtype.Split('_').First(),
+                          StringComparison.OrdinalIgnoreCase))
+                        {
+                            ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Degraded,
+                                "Braille embossing filename doesn't match expected braille type.",
+                                $"Embossing Braille Type: {match.Groups[4].Value} Expected Braille Type: {subtype.Split('_').First()} Filename {filename}");
+                        }
+                        if (!string.IsNullOrEmpty(match.Groups[5].Value) &&
+                            !match.Groups[5].Value.Equals("_transcript", StringComparison.OrdinalIgnoreCase))
                         // this item has a braille transcript
                         {
                             ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Severe,
-                                "Braille attachment suffix must be either 'transcript' or blank",
-                                $"Extension: {matches[0].Groups[5].Value} Filename: {filename}");
+                                "Braille embossing filename suffix must be either 'transcript' or blank",
+                                $"Suffix: {match.Groups[5].Value} Filename: {filename}");
                         }
-                        if (!matches[0].Groups[6].Value.Equals(attachType, StringComparison.OrdinalIgnoreCase))
+                        if (!match.Groups[6].Value.Equals(attachType, StringComparison.OrdinalIgnoreCase))
                         // Must match the type listed
                         {
                             ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Severe,
-                                "Braille attachment's extension is invalid. Extension must either be 'brf' or 'prn'",
-                                $"Extension: {matches[0].Groups[6].Value} Filename: {filename}");
+                                "Braille embossing filename extension is invalid; must either be 'brf' or 'prn'",
+                                $"Extension: {match.Groups[6].Value} Filename: {filename}");
                         }
                     }
                     else
@@ -1582,21 +1579,10 @@ namespace TabulateSmarterTestContentPackage
                          *       Concatenate the pattern code from the table above to the “Braille” column in ItemReport and StimulusReport. For example, “BRF UEB2” or “PRN UEB4”  
                          *       If the item has braille transcripts then concatenate both pattern codes. For example, “BRF Both4 Both6”. 
                          */
-                        if (string.IsNullOrEmpty(subtype) ||
-                            !subtype.Split('_')
-                                .Last().Equals("transcript", StringComparison.OrdinalIgnoreCase))
-                        {
-                            ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Degraded,
-                                "Attachment filename does not match file convention pattern",
-                                $"Filename: {filename}"
-                                );
-                        }
-                        else
-                        {
-                            ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Degraded,
-                                "Current validation target attachment filename does not match file convention pattern for Braille transcripts",
-                                $"Filename: {filename}");
-                        }
+                        ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Degraded,
+                            "Braille embossing filename does not match naming convention.",
+                            $"Filename: {filename}"
+                            );
                     }
 
                     // Report the result
@@ -1604,7 +1590,7 @@ namespace TabulateSmarterTestContentPackage
                     if (!brailleTypes.Add(brailleFile))
                     {
                         ReportingUtility.ReportError(it, ErrorCategory.Item, ErrorSeverity.Tolerable, 
-                            "Multiple attachments of same type and subtype.", "type='{0}'", brailleFile);
+                            "Multiple braille embossing files of same type and subtype.", "type='{0}'", brailleFile);
                     }
                 }
             }


### PR DESCRIPTION
Updates:

## ASL Video in .zip files
Reading the duration of ASL videos didn’t work when tabulating a .zip content package directly. Fixed.

By the way, it’s much more convenient to tabulate .zip files directly rather than unpack before tabulating. It also turns out to be quite a bit faster because much of what the tabulator does is I/O bound and reading compressed data from the .zip file is faster than reading uncompressed data.

## ReportError Overload
I see you have begun using String Interpolation when supplying the "detail" parameter to ReportError. Since ReportError accepts a FormatString type message with optional arguments this could result in a problem if the string happened to include curly brackets. Issue remedied by overloading ReportError with a version that accepts a "detail" parameter and no additional arguments.

## ASL Filename Validation False Positives
The filename validation for ASL filenames was throwing a lot of false-positive errors. Cleaned up the Regex on that to fix the problem.

## nLog
Long-term the use of nLog will be valuable. However, it was generating a lot of noise on the console and it was hard to follow what the tabulator was doing – especially when doing an aggregate tabulation of a bunch of zip files (as we do). Two changes:

* Added LogManager.DisableLogging() early in the program. Obviously if you need logging that should be turned on. This should probably be a command-line option.
* In the global exception catch at the end of main(), the exception is written BOTH to the log and to the console. Otherwise, key error messages (like having one of the output files open in Excel) are lost when logging is turned off.

Possible future enhancement:
* In a lot of places Logger.Error is doubled up with ReportingUtility.ReportError. It seems like ReportingUtility.ReportError could be modified to call Logger.Error and deliver more consistency.

## Partially fixed alt-text check – needs to be fixed completely
This is a legacy from an incomplete effort last year. The <img> tags never have alt text in the item source so this report an error for every image in the entire system (more than 35,000 errors). We need to fix this to work properly.

The correct test is to determine if the <img> tag has an ID (it must) and then look for an the apipAccessibility/accessibilityInfo/accessElement in the XML that includes a readAloud element – that’s where the alt text comes from and it’s added to the HTML at runtime.

Changed the test to look for the ID attribute instead of the alt attribute. That’s half of the solution – it eliminated the false-positives and checks for something that really must be present. To complete the test, it must look for the corresponding apipAccessibility/accessibilityInfo/accessElement in the item XML and ensure that element has a readAloud element.

Added a TODO comment where the remaining check should be.

There seems to be an implementation of this in Tabulator.cs – ReportMissingImgAltTags but that code is not called.

## Check for English Rubrics Only
The check for rubrics reported missing rubrics for any language in the system. We only care about English-language rubrics. Updated the test to only check for English.
