### PR TITLE
Bug fixes and enhanements

### DIFF
--- a/TabulateSmarterTestContentPackage/Extractors/ItemStandardExtractor.cs
+++ b/TabulateSmarterTestContentPackage/Extractors/ItemStandardExtractor.cs
@@ -10,6 +10,8 @@ namespace TabulateSmarterTestContentPackage.Extractors
 {
     public static class ItemStandardExtractor
     {
+        public static bool HasPrimaryStandard { get; set; }
+
         const string cSubjectMath = "MATH";
         const string cSubjectEla = "ELA";
         const string cValueNA = "NA";
@@ -55,9 +57,15 @@ namespace TabulateSmarterTestContentPackage.Extractors
                 string pubName = (publication.Evaluate("string(sa:Publication)", s_nsMetadata) as string) ?? string.Empty;
                 var pubStandards = new List<SmarterApp.ContentSpecId>();
 
+                // Get the primary standard
                 Extract(ii, grade, publication, "PrimaryStandard", pubStandards);
+                HasPrimaryStandard = true; // initially set to true
+
                 if (pubStandards.Count == 0)
                 {
+                    // If there are no primary standards, do not populate the Claim, Target, CCSS, and ClaimContentTarget fields in the item report. 
+                    // These fields are for reporting the primary standard values
+                    HasPrimaryStandard = false;
                     ReportingUtility.ReportError(ii, ErrorCategory.Metadata, ErrorSeverity.Tolerable, "No PrimaryStandard found for StandardPublication.", $"publication='{pubName}'");
                 }
                 else if (pubStandards.Count != 1)

--- a/TabulateSmarterTestContentPackage/Models/ContentSpecId.cs
+++ b/TabulateSmarterTestContentPackage/Models/ContentSpecId.cs
@@ -1367,7 +1367,7 @@ namespace SmarterApp
 
         #endregion
 
-        #region Derived Propoerties
+        #region Derived Properties
 
         public static string DeriveDomain(ContentSpecSubject subject, ContentSpecGrade grade, ContentSpecClaim claim, string target)
         {

--- a/TabulateSmarterTestContentPackage/TabulateSmarterTestContentPackage.csproj
+++ b/TabulateSmarterTestContentPackage/TabulateSmarterTestContentPackage.csproj
@@ -6,17 +6,18 @@
     <StartupObject>TabulateSmarterTestContentPackage.Program</StartupObject>
     <RuntimeIdentifiers>win-x64;win-x86</RuntimeIdentifiers>
     <NeutralLanguage />
-    <Version>3.4.1.0</Version>
-    <AssemblyVersion>3.4.1.0</AssemblyVersion>
-    <FileVersion>3.4.1.0</FileVersion>
+    <Version>3.4.2.0</Version>
+    <AssemblyVersion>3.4.2.0</AssemblyVersion>
+    <FileVersion>3.4.2.0</FileVersion>
     <Authors>Smarter Balanced Assessment Consortium</Authors>
     <Company>Smarter Balanced Assessment Consortium</Company>
     <Description>Validates and tabulates the contents of a Smarter Balanced Test Content Package</Description>
-    <Copyright>Copyright 2016-2018 Regents of the University of California</Copyright>
+    <Copyright>Copyright 2016-2019 Regents of the University of California</Copyright>
     <PackageLicenseUrl>https://opensource.org/licenses/ECL-2.0</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/SmarterApp/TabulateSmarterTestContentPackage</PackageProjectUrl>
     <RepositoryUrl>https://github.com/SmarterApp/TabulateSmarterTestContentPackage</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <ApplicationIcon />
   </PropertyGroup>
 
   <ItemGroup>

--- a/TabulateSmarterTestContentPackage/Validators/CDataValidator.cs
+++ b/TabulateSmarterTestContentPackage/Validators/CDataValidator.cs
@@ -55,10 +55,12 @@ namespace TabulateSmarterTestContentPackage.Validators
             if (language.Equals("ENU", StringComparison.OrdinalIgnoreCase) && Program.gValidationOptions.IsEnabled("tss"))
             {
                 // Silencing is appropriate for ELA Claim 2 Target 9
+                // on 2019-05-09, the checks for ELA, Claim 2, and Target 9 were all set to !=. Not sure if this was intentional or not, but
+                // shouldn't the logic be if the subject is equal to ELA, Claim equal to 2, and Target equal to 9?
                 if (primaryStandard == null
-                    || primaryStandard.Subject != SmarterApp.ContentSpecSubject.ELA
-                    || primaryStandard.Claim != SmarterApp.ContentSpecClaim.C2
-                    || !primaryStandard.Target.StartsWith("9"))
+                    || primaryStandard.Subject == SmarterApp.ContentSpecSubject.ELA
+                    || primaryStandard.Claim == SmarterApp.ContentSpecClaim.C2
+                    || primaryStandard.Target.StartsWith("9"))
                 {
                     ValidateTtsSilencingTags(it, contentElement.CreateNavigator(), htmlNav, brailleSupported);
                 }


### PR DESCRIPTION
Bug fixes
* flag indicator for no primary standard
* suppress TTS silencing for Math items

Enhancements
* additional fields in stim report
* change source of item version
* add error checks for Burmese, Somali, and Hmong
* add Burmese, Somali, Hmong, and Illustrations to item report
* apply all glossary errors to illustrations
* add missing translated and illustration glossaries to error report
* add additional ASL validation